### PR TITLE
修复message转换错误的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,11 @@
                 <artifactId>springfox-bean-validators</artifactId>
                 <version>${springfox.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/raincat-common/pom.xml
+++ b/raincat-common/pom.xml
@@ -105,6 +105,10 @@
             <artifactId>jedis</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/raincat-common/src/main/java/com/raincat/common/netty/bean/TxTransactionItem.java
+++ b/raincat-common/src/main/java/com/raincat/common/netty/bean/TxTransactionItem.java
@@ -18,9 +18,12 @@
 
 package com.raincat.common.netty.bean;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.raincat.common.enums.TransactionRoleEnum;
 import com.raincat.common.enums.TransactionStatusEnum;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
 
@@ -29,9 +32,14 @@ import java.io.Serializable;
  * @author xiaoyu
  */
 @Data
+@Slf4j
 public class TxTransactionItem implements Serializable {
 
     private static final long serialVersionUID = -983809184773470584L;
+    /**
+     *线程安全
+     */
+    private static final ObjectMapper OBJECT_MAPPER=new ObjectMapper();
 
     /**
      * taskKey.
@@ -97,5 +105,28 @@ public class TxTransactionItem implements Serializable {
      * 操作结果信息.
      */
     private Object message;
+
+
+    public void setMessage(Object message) {
+        if(message!=null && !( message instanceof String))
+        {
+            try
+            {
+                this.message=OBJECT_MAPPER.writeValueAsString(message);
+            }
+            catch (JsonProcessingException e)
+            {
+                this.message="internal server error,fail to parse object";
+                log.error("设置操作结果信息时出错，message:{}",message,e);
+            }
+
+        }
+        else
+        {
+            this.message = message;
+        }
+
+    }
+
 
 }

--- a/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-alipay/src/main/resources/applicationContext.xml
+++ b/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-alipay/src/main/resources/applicationContext.xml
@@ -18,7 +18,6 @@
         <property name="txManagerUrl" value="http://192.168.1.109:8761"/>
         <property name="serializer" value="kryo"/>
         <property name="nettySerializer" value="kryo"/>
-        <property name="blockingQueueType" value="Linked"/>
         <property name="compensation" value="true"/>
         <property name="compensationCacheType" value="db"/>
         <property name="txDbConfig">

--- a/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-pay/src/main/resources/applicationContext.xml
+++ b/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-pay/src/main/resources/applicationContext.xml
@@ -18,7 +18,6 @@
         <property name="txManagerUrl" value="http://192.168.1.109:8761"/>
         <property name="serializer" value="kryo"/>
         <property name="nettySerializer" value="kryo"/>
-        <property name="blockingQueueType" value="Linked"/>
         <property name="compensationCacheType" value="db"/>
         <property name="compensation" value="true"/>
         <property name="txDbConfig">

--- a/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-wechat/src/main/resources/applicationContext.xml
+++ b/raincat-sample/raincat-springcloud-sample/raincat-springcloud-sample-wechat/src/main/resources/applicationContext.xml
@@ -18,7 +18,6 @@
         <property name="txManagerUrl" value="http://192.168.1.109:8761"/>
         <property name="serializer" value="kryo"/>
         <property name="nettySerializer" value="kryo"/>
-        <property name="blockingQueueType" value="Linked"/>
         <property name="compensationCacheType" value="db"/>
         <property name="compensation" value="true"/>
         <property name="txDbConfig">


### PR DESCRIPTION
# 问题
netty序列化是默认使用的kryo。这种序列化有一个缺点，就是会记录类型信息。反序列化成对象的时候，如果项目中没有这个对象。那么就会报错。
![image](https://user-images.githubusercontent.com/9690089/44250811-8810e400-a228-11e8-940a-2543ec9f3e9f.png)
另外一个就是redis序列化是基于Jackson2JsonRedisSerializer，这种方式也是带类型信息。
而txManager需要记录事务执行的结果，放置到TxTransactionItem.message属性中。但是我们返回的结果都是自己的业务对象。
这样的话，为了程序正确允许。txManager和、admin项目必须依赖业务的实体对象。
否则爆错。

# 解决
每次设置TxTransactionItem.message属性,将对象储存为json字符串。再进行netty通讯或者redis的储存。这样就不会出错了。