### PR TITLE
修复查询事务组状态失败的问题

### DIFF
--- a/raincat-core/src/main/java/com/raincat/core/service/message/NettyMessageServiceImpl.java
+++ b/raincat-core/src/main/java/com/raincat/core/service/message/NettyMessageServiceImpl.java
@@ -79,6 +79,7 @@ public class NettyMessageServiceImpl implements TxManagerMessageService {
         heartBeat.setAction(NettyMessageActionEnum.GET_TRANSACTION_GROUP_STATUS.getCode());
         TxTransactionGroup txTransactionGroup = new TxTransactionGroup();
         txTransactionGroup.setId(txGroupId);
+        heartBeat.setTxTransactionGroup(txTransactionGroup);
         final Object object = nettyClientMessageHandler.sendTxManagerMessage(heartBeat);
         if (Objects.nonNull(object)) {
             return (Integer) object;


### PR DESCRIPTION
# bug原因
查询事务组状态时，未设置txTransactionGroup对象到心跳里面。会导致查询事务组状态失败。
# bug影响
如果一个参与者事务执行超时，调度线程被唤起，那么首先要做的是查询事务组状态，但是现在这个地方的bug会导致这个分布式事务失效。