### PR TITLE
修复补偿纪录插入可能会爆 主键重复 的问题

### DIFF
--- a/raincat-core/src/main/java/com/raincat/core/compensation/manager/TxCompensationManager.java
+++ b/raincat-core/src/main/java/com/raincat/core/compensation/manager/TxCompensationManager.java
@@ -24,6 +24,7 @@ import com.raincat.common.constant.CommonConstant;
 import com.raincat.common.enums.CompensationActionEnum;
 import com.raincat.common.enums.CompensationOperationTypeEnum;
 import com.raincat.common.enums.TransactionStatusEnum;
+import com.raincat.common.holder.IdWorkerUtils;
 import com.raincat.core.disruptor.publisher.TxTransactionEventPublisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -57,7 +58,7 @@ public class TxCompensationManager {
         TransactionRecover recover = new TransactionRecover();
         recover.setRetriedCount(1);
         recover.setStatus(TransactionStatusEnum.BEGIN.getCode());
-        recover.setId(groupId);
+        recover.setId(String.valueOf(IdWorkerUtils.getInstance().randomUUID()));
         recover.setTransactionInvocation(invocation);
         recover.setGroupId(groupId);
         recover.setTaskId(taskId);


### PR DESCRIPTION
# bug产生场景
假设有两个微服务，Order（订单）、member（会员）。
执行路径如下
Order.checkin();
||
\\/
Order===>Member.createMember()
||
\\/
Order===>Member.addFee()

也就是Order.checkin()在同一个分布式事务中，分别调用了两次Member的feign。此时Member微服务产生补偿记录时，会爆出主键重复的异常。导致整个分布式事务失败。

# bug产生原因
补偿id为groupId，应该替换成一个随机的唯一值。