### PR TITLE
http通知回滚或者提交时，url错误

### DIFF
--- a/raincat-manager/src/main/java/com/raincat/manager/config/Constant.java
+++ b/raincat-manager/src/main/java/com/raincat/manager/config/Constant.java
@@ -30,9 +30,9 @@ public interface Constant {
 
     String REDIS_KEYS = "transaction:group:*";
 
-    String HTTP_COMMIT = "http://%s/tx/manager/HTTP_COMMIT";
+    String HTTP_COMMIT = "http://%s/tx/manager/httpCommit";
 
-    String HTTP_ROLLBACK = "http://%s/tx/manager/HTTP_ROLLBACK";
+    String HTTP_ROLLBACK = "http://%s/tx/manager/httpRollBack";
 
 
 }


### PR DESCRIPTION
正确的地址：
![image](https://user-images.githubusercontent.com/9690089/44577913-da23ad80-a7c4-11e8-9839-056dcb584035.png)
改错误可能导致，预提交部分失败，或者通知回滚失败