### PR TITLE
 springCloud中的RestTemplateConfiguration自定义Feign.Builder拦截与开启hystrix冲突

### DIFF
--- a/raincat-core/pom.xml
+++ b/raincat-core/pom.xml
@@ -100,6 +100,10 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
 
     </dependencies>
     <build>

--- a/raincat-core/src/main/java/com/raincat/core/service/handler/ActorTxTransactionHandler.java
+++ b/raincat-core/src/main/java/com/raincat/core/service/handler/ActorTxTransactionHandler.java
@@ -28,6 +28,7 @@ import com.raincat.common.bean.TxTransactionInfo;
 import com.raincat.core.compensation.command.TxCompensationCommand;
 import com.raincat.core.concurrent.task.BlockTask;
 import com.raincat.core.concurrent.task.BlockTaskHelper;
+import com.raincat.core.concurrent.threadlocal.TxTransactionLocal;
 import com.raincat.core.concurrent.threadpool.TransactionThreadPool;
 import com.raincat.core.service.TxManagerMessageService;
 import com.raincat.core.service.TxTransactionHandler;
@@ -40,6 +41,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -77,10 +80,13 @@ public class ActorTxTransactionHandler implements TxTransactionHandler {
         LogUtil.info(LOGGER, "分布式事务参与方，开始执行,事务组id：{}", info::getTxGroupId);
         final String taskKey = IdWorkerUtils.getInstance().createTaskKey();
         final BlockTask task = BlockTaskHelper.getInstance().getTask(taskKey);
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
 
         transactionThreadPool
                 .newFixedThreadPool()
                 .execute(() -> {
+                    TxTransactionLocal.getInstance().setTxGroupId(info.getTxGroupId());
+                    RequestContextHolder.setRequestAttributes(requestAttributes);
                     final String waitKey = IdWorkerUtils.getInstance().createTaskKey();
                     final BlockTask waitTask = BlockTaskHelper.getInstance().getTask(waitKey);
                     DefaultTransactionDefinition def = new DefaultTransactionDefinition();

--- a/raincat-springcloud/src/main/java/com/raincat/springcloud/feign/RestTemplateConfiguration.java
+++ b/raincat-springcloud/src/main/java/com/raincat/springcloud/feign/RestTemplateConfiguration.java
@@ -18,7 +18,11 @@
 package com.raincat.springcloud.feign;
 
 
+import com.raincat.common.constant.CommonConstant;
+import com.raincat.core.concurrent.threadlocal.TxTransactionLocal;
 import feign.Feign;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -28,11 +32,24 @@ import org.springframework.context.annotation.Scope;
  */
 @Configuration
 public class RestTemplateConfiguration {
-
+/*
     @Bean
     @Scope("prototype")
     public Feign.Builder feignBuilder() {
         return Feign.builder().requestInterceptor(new RestTemplateInterceptor());
+    }*/
+
+    @Bean("txRequestInterceptor")
+    public RequestInterceptor txRequestInterceptor() {
+
+        return new RequestInterceptor() {
+            @Override
+            public void apply(RequestTemplate template) {
+                template.header(CommonConstant.TX_TRANSACTION_GROUP, TxTransactionLocal.getInstance().getTxGroupId());
+
+            }
+        };
     }
+
 
 }


### PR DESCRIPTION
作者在springCloud客户端中的RestTemplateConfiguration自定义Feign.Builder拦截Feign请求传递GroupId，这与开启hystrix冲突,feign开启hystrix后，定义了SleuthHystrixFeignBuilder，Feign.Builder全局只能有一个。

解决方法：改用bean的方式添加自定义的RequestInterceptor

然后发现事务参与者获取RequestContextHolder.getRequestAttributes()为null
原因：RequestContextHolder是一个threadlocal变量，事务参与者是新开线程执行的，传递不过去，需要在ActorTxTransactionHandler中传递一下RequestContextHolder
