### PR TITLE
解决完成提交未考虑返回结果的问题

### DIFF
--- a/raincat-manager/src/main/java/org/dromara/raincat/manager/netty/handler/NettyServerMessageHandler.java
+++ b/raincat-manager/src/main/java/org/dromara/raincat/manager/netty/handler/NettyServerMessageHandler.java
@@ -25,6 +25,7 @@ import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dromara.raincat.common.enums.NettyMessageActionEnum;
 import org.dromara.raincat.common.enums.NettyResultEnum;
 import org.dromara.raincat.common.holder.LogUtil;
@@ -129,6 +130,10 @@ public class NettyServerMessageHandler extends ChannelInboundHandlerAdapter {
                         txManagerService.updateTxTransactionItemStatus(txTransactionGroup.getId(),
                                 item.getTaskKey(),
                                 item.getStatus(), item.getMessage());
+                        //异步的情况下，就不要返回消息了（key为空就是异步）
+                        if(StringUtils.isNotBlank(hb.getKey())){
+                            ctx.writeAndFlush(buildSendMessage(hb.getKey(), true));
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
当补偿本地业务执行完成时，会通知manager完成整个事务。但是manager却没有返回结果。此时补偿处会等待超时。
![image](https://user-images.githubusercontent.com/9690089/50814660-66d69e80-1355-11e9-8865-6317b9c3278d.png)

微服务负载均衡，极端情况下，假设某次补偿定时任务中，补偿任务很多。
第一个任务就超时了，没来得及标记队列中其他的任务的last_time。
其他服务也启动了定时任务，此时可能会导致补偿重复。